### PR TITLE
含有辅修课程时的死循环问题

### DIFF
--- a/require_grade.php
+++ b/require_grade.php
@@ -166,6 +166,14 @@
 					$i++;
 					$number_of_lesson_fuxiu++;
 				}  
+				//辅修
+				if ($content[$i][9] == 1){
+					$total_score_fuxiu += ($content[$i][8] * $content[$i][6]);  //  累加总分
+					$total_value_fuxiu += $content[$i][6];    //  累加学分(权值)
+					$total_GPA_fuxiu += ($content[$i][7] * $content[$i][6]); //加权总绩点
+					$i++;
+					$number_of_lesson_fuxiu++;
+				}  
 				//普通课程
 				if ($content[$i][9] == 0){
 					$total_score += ($content[$i][8] * $content[$i][6]);  //  累加总分
@@ -292,6 +300,14 @@
 			$i = 5;
 			while(isset($content[$i][7])){
 				if ($content[$i][9] == 2){
+					echo '<div class="weui_cell">';
+					echo '<div class="weui_cell_bd weui_cell_primary">';
+					echo iconv("gb2312","utf-8//IGNORE",$content[$i][3])."  分数: ".$content[$i][8]."   课程学分: ".$content[$i][6];
+					echo '</div>';
+					echo '</div>';    
+				}     
+				//辅修信息
+				if ($content[$i][9] == 1){
 					echo '<div class="weui_cell">';
 					echo '<div class="weui_cell_bd weui_cell_primary">';
 					echo iconv("gb2312","utf-8//IGNORE",$content[$i][3])."  分数: ".$content[$i][8]."   课程学分: ".$content[$i][6];

--- a/require_grade.php
+++ b/require_grade.php
@@ -275,9 +275,7 @@
 		<!-- <script src="weui/dist/example/toast.js"></script> -->
 		<script src="//cdn.bootcss.com/jquery/3.1.0/jquery.min.js"></script>
 		<script src="/js/accordion.js"></script>
-		<script src="/js/require_score.js"></script>
-		</body>
-		</html>';
+		<script src="/js/require_score.js"></script>';
 		//输出课程明细,主修课程
 		echo '<div class="weui_cells_title">课程明细</div>';
 		echo '<div class="weui_cells">';
@@ -344,3 +342,5 @@
         return $td_array;
     }
 ?>
+</body>
+</html>


### PR DESCRIPTION
学长你好，

最近使用工大助手时发现当存在辅修课程时，网页会长时间卡死不能加载，或返回502。经分析原因如下：
在require_grade.php的156行的while循环中，只判断了$content[$i][9]为0或2的情况，但是辅修课程的$content[$i][9]值为1（猜测普通课程为0，辅修为1，双学位为2）。这样程序执行到这里时不会进入任何if分支，变量i也就无法自加，进而陷入死循环直至超时。
解决方案为加入$content[$i][9]为1的if判断，下面显示辅修成绩的部分同理。

此致
