### PR TITLE
修复含有辅修成绩的Overall GPA计算

### DIFF
--- a/login_grade.php
+++ b/login_grade.php
@@ -135,8 +135,7 @@
 <h1>
 <i class="weui_icon_success_circle"></i>&nbsp;账号和密码不会保留，请放心使用。<br>
 <i class="weui_icon_warn"></i>&nbsp;数据仅供参考，请以教务系统为准。<br></h1>
-<br>
-<p>总加权平均分和总平均 GPA 的数据只对<b>没报二专业/辅修</b>的同学有效。<br>
+<p>总加权平均分和总平均 GPA 的数据只对<b>没报双学位</b>的同学有效。<br>
 GPA 根据 <a href="http://undergrad.bjut.edu.cn/WebInfo.aspx?Id=752">北工大教务处文件</a>，采用四分制计算。其他学校可能采用不同算法。<br>
 如果存在分数不足60分的科目，默认加权分数计算则不包含该科目。<br>
 展开详情可以查看该科目补考通过后的参考均分</p>

--- a/require_grade.php
+++ b/require_grade.php
@@ -121,7 +121,11 @@
 		//计算总和的东西，学分/GPA
 		while(isset($content_allgrade[$i][4])){
 			//不计算第二课堂和新生研讨课以及未通过课程
-			if ($content_allgrade[$i][5] == iconv("utf-8","gb2312//IGNORE","第二课堂") || $content_allgrade[$i][1] == iconv("utf-8","gb2312//IGNORE","新生研讨课") || $content_allgrade[$i][4] < 60){
+			if ($content_allgrade[$i][5] == iconv("utf-8","gb2312//IGNORE","第二课堂") 
+			|| $content_allgrade[$i][1] == iconv("utf-8","gb2312//IGNORE","新生研讨课") 
+			|| $content_allgrade[$i][4] < 60 
+			|| strpos(mb_convert_encoding($content_allgrade[$i][2], 'utf-8', 'gb2312'), "（辅）")) {
+				//通过判断课程类型中的“（辅）”字样来过滤辅修成绩
 				if ($content_allgrade[$i][4] < 60 && is_numeric($content_allgrade[$i][4])){
 					$all_number_of_lesson_with_nopass++;
 					$all_score_with_nopass += ($content_allgrade[$i][3] * $content_allgrade[$i][4]);


### PR DESCRIPTION
你好，

在总成绩页面中，辅修课程在课程性质栏中含有“（辅）”字样用于区分，如图。
![2018-06-24 5 47 33](https://user-images.githubusercontent.com/13297785/41817940-48f18e76-77d7-11e8-87a4-568d959c1aae.png)
因此在计算Overall GPA时可以在课程性质字符串中查找“（辅）”字样，如果含有则过滤。
理论上双学位也可以通过类似方法区分，但是由于不知道其标识，暂时无法实现。

此致
